### PR TITLE
[ch33661] [Intermittent] TypeError: Cannot use 'in' operator to search for 'ordering' in null

### DIFF
--- a/src_ts/routing/routes.ts
+++ b/src_ts/routing/routes.ts
@@ -184,7 +184,7 @@ export function updateQueryParams(newQueryParams: EtoolsRouteQueryParams, reset 
   const details: EtoolsRouteDetails | null = EtoolsRouter.getRouteDetails();
   const path: string = (details && details.path) || '';
   let currentParams: EtoolsRouteQueryParams | null = details && details.queryParams;
-  if (reset) {
+  if (reset && currentParams) {
     currentParams = pick(['ordering', 'page_size'], currentParams);
   }
   const computed: EtoolsRouteQueryParams = Object.assign({}, currentParams, newQueryParams);


### PR DESCRIPTION
[ch33661]  [Intermittent] TypeError: Cannot use 'in' operator to search for 'ordering' in null